### PR TITLE
Add test for Manager.share and update dat.download

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hyperdrive": "^3.5.1",
     "level": "^1.3.0",
     "mkdirp": "^0.5.1",
+    "pump": "^1.0.1",
     "run-parallel": "^1.1.4",
     "stream-each": "^1.1.2",
     "through2": "^2.0.1"

--- a/tests/test.js
+++ b/tests/test.js
@@ -46,6 +46,7 @@ test('manager share', function (t) {
     var db = LocalDat({})
     db.download(data.value.link, tmpDir, function (err, stats) {
       t.ifError(err)
+      t.same(stats.filesRead, 1, 'one file read')
       manager.close(function () {
         db.close()
         t.end()

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,6 +1,8 @@
 var Manager = require('../')
 var Dat = require('dat')
+var LocalDat = require('../dat')
 var path = require('path')
+var os = require('os')
 var memdb = require('memdb')
 var test = require('tape')
 
@@ -28,6 +30,25 @@ test('manager start and stop', function (t) {
             t.end()
           })
         })
+      })
+    })
+  })
+})
+
+test('manager share', function (t) {
+  var manager = Manager()
+  var shareFiles = path.join(__dirname, 'fixtures')
+  var tmpDir = os.tmpDir()
+  manager.share('manager_share_test', shareFiles, function (err, data) {
+    t.ifError(err)
+    t.same(data.key, 'manager_share_test')
+    t.same(data.value.state, 'active')
+    var db = LocalDat({})
+    db.download(data.value.link, tmpDir, function (err, stats) {
+      t.ifError(err)
+      manager.close(function () {
+        db.close()
+        t.end()
       })
     })
   })

--- a/tests/test.js
+++ b/tests/test.js
@@ -46,7 +46,7 @@ test('manager share', function (t) {
     var db = LocalDat({})
     db.download(data.value.link, tmpDir, function (err, stats) {
       t.ifError(err)
-      t.same(stats.filesRead, 1, 'one file read')
+      t.same(stats.filesDownloaded, 1, 'one file read')
       manager.close(function () {
         db.close()
         t.end()


### PR DESCRIPTION
* Adds test for `Manager.share` function
* Updates `dat.download` to use pump (was exiting too early before)
* Add pump + through2 to dependencies